### PR TITLE
GPIM-36: Add spaceId in productLabel field and fix links

### DIFF
--- a/grid-products/data-model.md
+++ b/grid-products/data-model.md
@@ -9,7 +9,7 @@ To learn about the definition of each field, check out the [Field Definitions](/
 interface GridProduct {
   productId: string;
   // spaceIds will hold the list of spaceIds where item is visible
-  spaceIds?: Array<string>;
+  spaceIds: Array<string>;
   productShortDescription?: Array<{
     isoLanguageId: IsoLanguageIds;
     productShortDescription: string;
@@ -124,7 +124,8 @@ interface GridProduct {
   // Product Labels - displayed like stickers
   productLabel?: Array<{
     isoLanguageId: IsoLanguageIds;
-    productLabel: string; // Ex. [Online Exclusive]
+    spaceId: string;
+    productLabel: string; // Ex. Online Exclusive
   }>;
 
   // Product Tags to increase searchability of a product

--- a/grid-products/field-definitions.md
+++ b/grid-products/field-definitions.md
@@ -60,7 +60,7 @@ productStatus is a **required** field.
 | ----------------- | ------------------------------------------- | -------- | ---------------------------------------------------- |
 | productStatus     | Status value of the product                 | Yes      | `active` or `inactive`                               |
 | isoLanguageId     | Iso Language ID in BCP-47 format            | Yes      | [ISOLanguageID](/grid-products/data-model?id=languageids) |
-| spaceId           | Store ID where product status is applicable |          |                                                      |
+| spaceId           | Space where product status is applicable |          |                                                      |
 | periodStartDate   | Status duration start                       |          |                                                      |
 | periodEndDate     | Status duration end                         |          |                                                      |
 | productStatusNote |                                             |          |                                                      |
@@ -108,6 +108,7 @@ productLabel is *not* a required property that contains an Array of Objects, one
 | Field         | Description                            | Required | Example                                              |
 | ------------- | -------------------------------------- | -------- | ---------------------------------------------------- |
 | productLabel  | Translation value of the product label | Yes      |                                                      |
+| spaceId  | Space where product label is applicable | Yes      |                                                      |
 | isoLanguageId | Iso Language ID in BCP-47 format       | Yes      | [ISOLanguageID](/grid-products/data-model?id=languageids) |
 
 

--- a/grid-products/integration-flow.md
+++ b/grid-products/integration-flow.md
@@ -10,16 +10,16 @@ You'll need the following information:
 2. Any Environment id that you have defined in the Grid Console (e.g. prod)
 3. Access Token
   - You need to generate an Access Token under "Developers" tab to be used later on for every request
-     - [Products API](/grid-pim/api?id=request-authentication)
-     - [Spaces API](/grid-pim/spaces-api?id=request-authentication)
+     - [Products API](/grid-products/api?id=request-authentication)
+     - [Spaces API](/grid-products/spaces-api?id=request-authentication)
 
 ## 2. Push Spaces
 
 This step is applicable if you want your data to be visible only to a specific store / location for example.
 
-To Read about how to create spaces into the database using our API, check the [Create Space endpoint](/grid-pim/api?id=post-space) in the API reference.
+To Read about how to create spaces into the database using our API, check the [Create Space endpoint](/grid-products/api?id=post-space) in the API reference.
 
-The returned `id` value will be used as values for `spaceIds` and `spaceId` fields later on when you format your product data into the [GridProduct](/grid-pim/data-model?id=gridproduct) format
+The returned `id` value will be used as values for `spaceIds` and `spaceId` fields later on when you format your product data into the [GridProduct](/grid-products/data-model?id=gridproduct) format
 
 ## 3. Push ProductTypes
 
@@ -27,7 +27,7 @@ The next step would be to push your product categories or product types that wil
 
 Specific example for ProductTypes usage is for the category navigation in Endless Aisle application.
 
-To Read about how to push product types into the database using our API, check the [Push Product Types endpoint](/grid-pim/api?id=post-push-product-types) in the API reference.
+To Read about how to push product types into the database using our API, check the [Push Product Types endpoint](/grid-products/api?id=post-push-product-types) in the API reference.
 
 
 ## 4. Push Products

--- a/grid-products/releasenotes/README.md
+++ b/grid-products/releasenotes/README.md
@@ -1,6 +1,12 @@
 # Grid Product Release Notes
 Grid Product receives continuous updates. All the recent release notes can be found below in order of release. 
 
+## 2021-01-17
+
+#### Model Updates
+- Added `spaceId` on `productLabel` fields
+- Fixed links
+
 ## 2021-01-04
 
 #### Integration Flow

--- a/grid-products/spaces-api.md
+++ b/grid-products/spaces-api.md
@@ -20,7 +20,7 @@ For easy configuration and testing, here's a Postman collection you can import i
 ## URL's overview
 
 Grid Admin API:
-https://api.omborigrid.com
+https://api.omborigrid.com/api
 
 
 > In every endpoint you will need to replace `{base-url}` with the URL specified above.
@@ -86,7 +86,7 @@ The body of the request should be a [Space]((/grid-products/data-model?id=space)
 | -------------- | ------ | ------------------------------------------------------- | -------------------- |
 | organizationId | string | The organization/tenant where the space will be created | `61cxxxxxxxxxxxxxxx` |
 | displayName    | string | The name of the space to be displayed                   | `Store #1`           |
-| type           | string | The type of the space ('location'                       | 'section'            | 'custom') | `location` |
+| type           | string | The type of the space (`location`,`section`,`custom`) | `location` |
 | longitude      | number | Longitude of the space                                  | `59.32960273523599`  |
 | latitude       | number | Latitude of the space                                   | `18.06886331765492`  |
 | externalId     | string | Id of the space managed externally                      | `store_1`            |


### PR DESCRIPTION
### Description
1. Add required spaceId in productLabel fields
2. Fixed links (`grid-pim/` to `grid-products/`)
3. Fixed tables content
4. Fixed spaces API base url
5. Fixed type of `spaceIds` field